### PR TITLE
Topics are not auto-creating in the proxy

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -165,7 +165,7 @@ action :add do
       retries 2
       variables(:kafka_topics => kafka_topics, :managers_list => managers_list)
       notifies :run, "bash[create_topics]", :delayed
-      only_if 'ping -c 1 zookeeper.service'
+      only_if 'nc -zv zookeeper.service 2181'
     end
 
     service "kafka" do


### PR DESCRIPTION
* the check using `ping` in the proxy is wrong, since in the manager we use consult that is ok but in the proxy we hard-code the dns in `/etc/hosts`so its not really checking the zookeeper since it will auto-redir to localhost