### PR TITLE
Improvement/fix cookbook lint

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,9 +1,9 @@
-default["kafka"]["logfile"] = "/var/log/kafka"
-default["kafka"]["user"] = "kafka"
-default["kafka"]["group"] = "kafka"
-default["kafka"]["port"] = 9092
-default["kafka"]["zk_hosts"] = "localhost:2181"
-default["kafka"]["host_index"] = 0
+default['kafka']['logfile'] = '/var/log/kafka'
+default['kafka']['user'] = 'kafka'
+default['kafka']['group'] = 'kafka'
+default['kafka']['port'] = 9092
+default['kafka']['zk_hosts'] = 'localhost:2181'
+default['kafka']['host_index'] = 0
 
-#Flags
-default["kafka"]["registered"] = false
+# Flags
+default['kafka']['registered'] = false

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -1,9 +1,8 @@
 name             'kafka'
 maintainer       'Redborder'
-maintainer_email 'ejimenez@redborder.com'
+maintainer_email 'manegron@redborder.com'
 license          'All rights reserved'
 description      'Installs/Configures kafka'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.9'
 
-depends "zookeeper"
+depends 'zookeeper'

--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -1,7 +1,5 @@
-# Cookbook Name:: kafka
-#
+# Cookbook:: kafka
 # Provider:: config
-#
 
 action :add do
   begin
@@ -14,42 +12,41 @@ action :add do
     port = new_resource.port
     managers_list = new_resource.managers_list
     maxsize = new_resource.maxsize
-    ipaddress = new_resource.ipaddress
-    is_proxy = node["redborder"]["is_proxy"]
-    is_manager = node["redborder"]["is_manager"]
+    is_proxy = node['redborder']['is_proxy']
+    is_manager = node['redborder']['is_manager']
     # Calculate kafka_topics that need to be created
     kafka_topics = []
     if is_manager
-      kafka_topics = ["rb_event", "rb_event_post",
-                      "rb_flow", "rb_flow_post", "rb_flow_discard",
-                      "rb_monitor", "rb_monitor_post",
-                      "rb_loc", "rb_locne", "rb_loc_post", "rb_loc_post_discard", "rb_location",
-                      "rb_trap",
-                      "rb_mobile",
-                      "rb_radius",
-                      "rb_nmsp",
-                      "rb_malware",
-                      "rb_mail",
-                      "rb_metrics",
-                      "rb_state", "rb_state_post",
-                      "rb_meraki",
-                      "rb_vault", "rb_vault_post",
-                      "rb_bi", "rb_bi_post",
-                      "rb_scanner", "rb_scanner_post",
-                      "rb_http2k_sync",
-                      "rb_limits",
-                      "rb_counters",
-                      "sflow",
-                      "rb_wireless"]
-      namespaces              = []
-      Chef::Role.list.keys.each do |rol|
+      kafka_topics = %w(rb_event rb_event_post
+                      rb_flow rb_flow_post rb_flow_discard
+                      rb_monitor rb_monitor_post
+                      rb_loc rb_locne rb_loc_post rb_loc_post_discard rb_location
+                      rb_trap
+                      rb_mobile
+                      rb_radius
+                      rb_nmsp
+                      rb_malware
+                      rb_mail
+                      rb_metrics
+                      rb_state rb_state_post
+                      rb_meraki
+                      rb_vault rb_vault_post
+                      rb_bi rb_bi_post
+                      rb_scanner rb_scanner_post
+                      rb_http2k_sync
+                      rb_limits
+                      rb_counters
+                      sflow
+                      rb_wireless)
+      namespaces = []
+      Chef::Role.list.each_key do |rol|
         ro = Chef::Role.load rol
-        if ro and ro.override_attributes["redborder"] and ro.override_attributes["redborder"]["namespace"] and ro.override_attributes["redborder"]["namespace_uuid"] and !ro.override_attributes["redborder"]["namespace_uuid"].empty?
-          namespaces.push(ro.override_attributes["redborder"]["namespace_uuid"])
+        if ro && ro.override_attributes['redborder'] && ro.override_attributes['redborder']['namespace'] && ro.override_attributes['redborder']['namespace_uuid'] && !ro.override_attributes['redborder']['namespace_uuid'].empty?
+          namespaces.push(ro.override_attributes['redborder']['namespace_uuid'])
         end
       end
       namespaces.uniq!
-      topics_with_namespaces = ["rb_flow_post", "rb_vault_post", "rb_loc_post", "rb_event_post", "rb_monitor_post", "rb_state_post", "rb_bi_post", "rb_scanner_post", "rb_wireless"]
+      topics_with_namespaces = %w(rb_flow_post rb_vault_post rb_loc_post rb_event_post rb_monitor_post rb_state_post rb_bi_post rb_scanner_post rb_wireless)
       namespaces.each do |ns|
         topics_with_namespaces.each do |topic|
           kafka_topics.push("#{topic}_#{ns}")
@@ -58,28 +55,28 @@ action :add do
     end
 
     if is_proxy
-      kafka_topics = ["rb_event",
-                      "rb_flow",
-                      "rb_monitor",
-                      "rb_loc",
-                      "rb_nmsp",
-                      "rb_social",
-                      "rb_state",
-                      "rb_radius",
-                      "rb_vault",
-                      "rb_hashtag",
-                      "sflow",
-                      "rb_scanner",
-                      "rb_host_discovery",
-                      "rb_wireless"]
+      kafka_topics = %w(rb_event
+                      rb_flow
+                      rb_monitor
+                      rb_loc
+                      rb_nmsp
+                      rb_social
+                      rb_state
+                      rb_radius
+                      rb_vault
+                      rb_hashtag
+                      sflow
+                      rb_scanner
+                      rb_host_discovery
+                      rb_wireless)
     end
-     
-    dnf_package "redborder-kafka" do
+
+    dnf_package 'redborder-kafka' do
       action :upgrade
       flush_cache [ :before ]
     end
 
-    execute "create_user" do
+    execute 'create_user' do
       command "/usr/sbin/useradd #{user}"
       ignore_failure true
       not_if "getent passwd #{user}"
@@ -88,111 +85,111 @@ action :add do
     directory logdir do
       owner user
       group group
-      mode 0770
+      mode '0770'
       action :create
     end
 
-    directory "/tmp/kafka" do
+    directory '/tmp/kafka' do
       owner user
       group group
-      mode 0755
+      mode '0755'
       action :create
     end
 
-    directory "/etc/kafka" do
+    directory '/etc/kafka' do
       owner user
       group group
-      mode 0755
+      mode '0755'
     end
 
-    template "/etc/kafka/consumer.properties" do
-      source "kafka_consumer.properties.erb"
+    template '/etc/kafka/consumer.properties' do
+      source 'kafka_consumer.properties.erb'
       owner user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
       retries 2
-      variables(:zk_hosts => zk_hosts)
+      variables(zk_hosts: zk_hosts)
     end
 
-    template "/etc/kafka/log4j.properties" do
-      source "kafka_log4j.properties.erb"
+    template '/etc/kafka/log4j.properties' do
+      source 'kafka_log4j.properties.erb'
       owner user
       group group
-      mode 0644
-      cookbook "kafka"
+      mode '0644'
+      cookbook 'kafka'
       retries 2
-      notifies :restart, "service[kafka]", :delayed
+      notifies :restart, 'service[kafka]', :delayed
     end
 
-    template "/etc/kafka/producer.properties" do
-      source "kafka_producer.properties.erb"
+    template '/etc/kafka/producer.properties' do
+      source 'kafka_producer.properties.erb'
       owner user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
       retries 2
-      variables(:managers_list => managers_list, :port => port)
+      variables(managers_list: managers_list, port: port)
     end
 
-     template "/etc/sysconfig/kafka" do
-        source "kafka_sysconfig.erb"
-        owner user
-        group group
-        cookbook "kafka"
-        mode 0644
-        retries 2
-        variables(:memory => memory)
-        notifies :restart, "service[kafka]", :delayed
-    end
-
-    template "/etc/kafka/tools-log4j.properties" do
-      source "kafka_tools-log4j.properties.erb"
+    template '/etc/sysconfig/kafka' do
+      source 'kafka_sysconfig.erb'
       owner user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
+      retries 2
+      variables(memory: memory)
+      notifies :restart, 'service[kafka]', :delayed
+    end
+
+    template '/etc/kafka/tools-log4j.properties' do
+      source 'kafka_tools-log4j.properties.erb'
+      owner user
+      group group
+      cookbook 'kafka'
+      mode '0644'
       retries 2
     end
 
-    template "/etc/kafka/server.properties" do
-      source "kafka_server.properties.erb"
+    template '/etc/kafka/server.properties' do
+      source 'kafka_server.properties.erb'
       owner  user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
       retries 2
-      notifies :restart, "service[kafka]", :delayed
-     variables(:is_proxy => is_proxy, :managers_list => managers_list, :host_index => host_index, :zk_hosts => zk_hosts, :maxsize => maxsize )
+      notifies :restart, 'service[kafka]', :delayed
+      variables(is_proxy: is_proxy, managers_list: managers_list, host_index: host_index, zk_hosts: zk_hosts, maxsize: maxsize)
     end
 
-    template "/etc/kafka/brokers.list" do
-      source "kafka_brokers.list.erb"
+    template '/etc/kafka/brokers.list' do
+      source 'kafka_brokers.list.erb'
       owner user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
       retries 2
-      variables(:managers_list => managers_list, :port => port)
-      notifies :restart, "service[kafka]", :delayed if host_index>=0
+      variables(managers_list: managers_list, port: port)
+      notifies :restart, 'service[kafka]', :delayed if host_index >= 0
     end
 
-    template "/etc/kafka/topics_definitions.yml" do
-      source "topics_definitions.yml.erb"
+    template '/etc/kafka/topics_definitions.yml' do
+      source 'topics_definitions.yml.erb'
       owner user
       group group
-      cookbook "kafka"
-      mode 0644
+      cookbook 'kafka'
+      mode '0644'
       retries 2
-      variables(:kafka_topics => kafka_topics, :managers_list => managers_list)
-      notifies :run, "bash[create_topics]", :delayed
+      variables(kafka_topics: kafka_topics, managers_list: managers_list)
+      notifies :run, 'bash[create_topics]', :delayed
       only_if 'nc -zv zookeeper.service 2181'
     end
 
-    service "kafka" do
-      service_name "kafka"
-      supports :status => true, :reload => true, :restart => true, :start => true, :enable => true
-      action [:enable,:start]
+    service 'kafka' do
+      service_name 'kafka'
+      supports status: true, reload: true, restart: true, start: true, enable: true
+      action [:enable, :start]
     end
 
     #################################
@@ -208,7 +205,7 @@ action :add do
       action :nothing
     end
 
-    Chef::Log.info("Kafka cookbook has been processed")
+    Chef::Log.info('Kafka cookbook has been processed')
   rescue => e
     Chef::Log.error(e.message)
   end
@@ -216,30 +213,22 @@ end
 
 action :remove do
   begin
-
     logdir = new_resource.logdir
-    host_index = new_resource.host_index
 
-    service "kafka" do
-      supports :stop => true
+    service 'kafka' do
+      supports stop: true
       action :stop
     end
 
-    template_list = [
-                     "/etc/kafka/brokers.list",
-                     "/etc/kafka/server.properties",
-                     "/etc/kafka/tools-log4j.properties",
-                     "/etc/sysconfig/kafka",
-                     "/etc/kafka/producer.properties",
-                     "/etc/kafka/log4j.properties",
-                     "/etc/kafka/consumer.properties"
-                    ]
+    template_list = %w(/etc/kafka/brokers.list
+                       /etc/kafka/server.properties
+                       /etc/kafka/tools-log4j.properties
+                       /etc/sysconfig/kafka
+                       /etc/kafka/producer.properties
+                       /etc/kafka/log4j.properties
+                       /etc/kafka/consumer.properties)
 
-    dir_list = [
-                 "/etc/kafka",
-                 "/tmp/kafka",
-                 logdir
-               ]
+    dir_list = ['/etc/kafka', '/tmp/kafka', logdir]
 
     # removing templates
     template_list.each do |temp|
@@ -260,7 +249,7 @@ action :remove do
       action :remove
     end
 
-    Chef::Log.info("Kafka cookbook has been processed")
+    Chef::Log.info('Kafka cookbook has been processed')
   rescue => e
     Chef::Log.error(e.message)
   end
@@ -269,23 +258,23 @@ end
 action :register do
   begin
     ipaddress = new_resource.ipaddress
-    if !node["kafka"]["registered"]
+    unless node['kafka']['registered']
       query = {}
-      query["ID"] = "kafka-#{node["hostname"]}"
-      query["Name"] = "kafka"
-      query["Address"] = ipaddress 
-      query["Port"] = 9092
+      query['ID'] = "kafka-#{node['hostname']}"
+      query['Name'] = 'kafka'
+      query['Address'] = ipaddress
+      query['Port'] = 9092
       json_query = Chef::JSONCompat.to_json(query)
 
       execute 'Register service in consul' do
-         command "curl -X PUT http://localhost:8500/v1/agent/service/register -d '#{json_query}' &>/dev/null"
-         action :nothing
+        command "curl -X PUT http://localhost:8500/v1/agent/service/register -d '#{json_query}' &>/dev/null"
+        action :nothing
       end.run_action(:run)
 
-      node.normal["kafka"]["registered"] = true
+      node.normal['kafka']['registered'] = true
     end
 
-    Chef::Log.info("Kafka services has been registered to consul")
+    Chef::Log.info('Kafka services has been registered to consul')
   rescue => e
     Chef::Log.error(e.message)
   end
@@ -293,17 +282,16 @@ end
 
 action :deregister do
   begin
-    ipaddress = new_resource.ipaddress
-    if node["kafka"]["registered"]
+    if node['kafka']['registered']
       execute 'Deregister service in consul' do
-        command "curl -X PUT http://localhost:8500/v1/agent/service/deregister/kafka-#{node["hostname"]} &>/dev/null"
+        command "curl -X PUT http://localhost:8500/v1/agent/service/deregister/kafka-#{node['hostname']} &>/dev/null"
         action :nothing
       end.run_action(:run)
 
-      node.normal["kafka"]["registered"] = false
+      node.normal['kafka']['registered'] = false
     end
 
-    Chef::Log.info("Kafka services has been deregistered to consul")
+    Chef::Log.info('Kafka services has been deregistered to consul')
   rescue => e
     Chef::Log.error(e.message)
   end

--- a/resources/recipes/default.rb
+++ b/resources/recipes/default.rb
@@ -1,17 +1,11 @@
-#
-# Cookbook Name:: kafka
+# Cookbook:: kafka
 # Recipe:: default
-#
-# Copyright 2016, redborder
-#
-# All rights reserved - Do Not Redistribute
-#
-#
+# Copyright:: 2024, redborder
+# License:: Affero General Public License, Version 3
 
-kafka_config "Kafka node configuration" do
-  zk_hosts node["kafka"]["zk_hosts"]
-  host_index node["kafka"]["host_index"]
-  port node["kafka"]["port"]
+kafka_config 'Kafka node configuration' do
+  zk_hosts node['kafka']['zk_hosts']
+  host_index node['kafka']['host_index']
+  port node['kafka']['port']
   action :add
 end
-

--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -1,18 +1,16 @@
-# Cookbook Name:: kafka
-#
+# Cookbook:: kafka
 # Resource:: config
-#
 
 actions :add, :remove, :register, :deregister
 default_action :add
 
-attribute :memory, :kind_of => Fixnum, :default => 524288
-attribute :logdir, :kind_of => String, :default => "/var/log/kafka"
-attribute :user, :kind_of => String, :default => "kafka"
-attribute :group, :kind_of => String, :default => "kafka"
-attribute :host_index, :kind_of => Fixnum, :default => 0
-attribute :zk_hosts, :kind_of => String, :default => "localhost:2181"
-attribute :managers_list, :kind_of => Array, :default => ["localhost"]
-attribute :port, :kind_of => Fixnum, :default => 9092
-attribute :maxsize, :kind_of => Float, :default => 1024.0
-attribute :ipaddress, :kind_of => String, :default => "127.0.0.1"
+attribute :memory, kind_of: Integer, default: 524288
+attribute :logdir, kind_of: String, default: '/var/log/kafka'
+attribute :user, kind_of: String, default: 'kafka'
+attribute :group, kind_of: String, default: 'kafka'
+attribute :host_index, kind_of: Integer, default: 0
+attribute :zk_hosts, kind_of: String, default: 'localhost:2181'
+attribute :managers_list, kind_of: Array, default: ['localhost']
+attribute :port, kind_of: Integer, default: 9092
+attribute :maxsize, kind_of: Float, default: 1024.0
+attribute :ipaddress, kind_of: String, default: '127.0.0.1'


### PR DESCRIPTION
- This PR addresses and fixes all important lint issues reported by cookstyle

Main Changes:
- Use of %w for word arrays
- Replacing keys.each with each_key
- Replace " with ' when there is not interpolation

I tested the update in a manager and seems to works, but we still need to test this with a clean installation in manager & proxy