### PR TITLE
BugFix#18543 maxSize and segment max cache size is not pass (right now is using the default value)

### DIFF
--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -12,5 +12,5 @@ attribute :host_index, kind_of: Integer, default: 0
 attribute :zk_hosts, kind_of: String, default: 'localhost:2181'
 attribute :managers_list, kind_of: Array, default: ['localhost']
 attribute :port, kind_of: Integer, default: 9092
-attribute :maxsize, kind_of: Float, default: 1024.0
+attribute :maxsize, kind_of: Integer, default: 1024
 attribute :ipaddress, kind_of: String, default: '127.0.0.1'


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/18543)

## Description

`harddisk_services.rb` library method from`cookbook-rb-manager` is now passing `hd_services_current` as an Integer instead of Float value.