### PR TITLE
Bugfix/#22557 Topic rb_malware listed 2x in topics_definitions.yml

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -25,7 +25,6 @@ action :add do
                       rb_mobile
                       rb_radius
                       rb_nmsp
-                      rb_malware
                       rb_mail
                       rb_metrics
                       rb_state rb_state_post


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/22557)

## Description

Remove an entry of `rb_malware` in kafka_topics list.